### PR TITLE
Fix supercarrier verification for the localized version of the game

### DIFF
--- a/VAICOM/Client/Call handling/Core.aicomms.processcommand.cs
+++ b/VAICOM/Client/Call handling/Core.aicomms.processcommand.cs
@@ -646,13 +646,12 @@ namespace VAICOM
                             }
 
                             if (State.currentcommand.isCarrier() && !State.currentmessageunit.descr.ToLower().Contains("supercarrier"))
-                                if (State.currentcommand.isCarrier() && !State.currentmessageunit.fullname.ToLower().Contains("forrestal"))
-                                    if (State.currentcommand.isCarrier() && !State.currentmessageunit.fullname.ToLower().Contains("stennis"))
-                                    {
-                                        Log.Write("Selected recipient is not a Supercarrier unit.", Colors.Warning); // Pene changes to allow non SC units if module is installed
-                                        UI.Playsound.Error();
-                                        return true; //true
-                                    }
+                                if (State.currentcommand.isCarrier() && !State.currentmessageunit.fullname.ToLower().Contains("cvn-"))
+                                {
+                                    Log.Write("Selected recipient is not a Supercarrier unit.", Colors.Warning); // Pene changes to allow non SC units if module is installed
+                                    UI.Playsound.Error();
+                                    return true; //true
+                                }
                         }
 
                         // ---------------------------  


### PR DESCRIPTION
To prevent "Selected recipient is not a Supercarrier unit." in localized version of the game